### PR TITLE
Fix problems with `phonegap platform add android`

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.cordovaplugincamerapreview.sample-app" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.cordovaplugincamerapreview.sampleapp" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>cordova-plugin-camera-sample-app</name>
     <description>A sample Cordova application for cordova-plugin-camera-preview.</description>
     <author email="dev@cordova.apache.org" href="http://cordova.io">Sample App</author>


### PR DESCRIPTION
In the latest phonegap versions, a validation is made over the id of the app, that requires it to be like a valid java package identifier (sort of a backwards URL, but can't contain dashes).

Without this change, `phonegap platform add android` fails with `Error: Error validating package name. Package name must look like: com.company.Name`
