### PR TITLE
fix getPictureSizes function

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -58,7 +58,7 @@
         <button id="showButton">Show</button>
       </div>
       <div class="block">
-        <button id="showSupportedPictureSize">Supported Picture Size</button>
+        <button id="showSupportedPictureSizes">Supported Picture Sizes</button>
       </div>
     </div>
 

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -83,7 +83,7 @@ var app = {
     window.smallPreview = false;
     document.getElementById('changePreviewSize').addEventListener('click', this.changePreviewSize, false);
 
-    document.getElementById('showSupportedPictureSize').addEventListener('click', this.showSupportedPictureSize, false);
+    document.getElementById('showSupportedPictureSizes').addEventListener('click', this.showSupportedPictureSizes, false);
 
     // legacy - not sure if this was supposed to fix anything
     //window.addEventListener('orientationchange', this.onStopCamera, false);


### PR DESCRIPTION
There is a typo in the function name.

I pluralized all the 'sizes' for consistency.